### PR TITLE
bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 tests
 
+# PyCharm
+
+.idea/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Software 3D Renderer in Python
 - Python 2 or Python 3
 - PyOpenGL
 - NumPy
+- watchdog
+- nose
 
 ## Licence
 Apache 2.0

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from glutwindow import GlutWindow
 if __name__ == '__main__':
     width = 400
     height = 300
-    title = 'Screen.py'
+    title = b'Screen.py'
 
     win = GlutWindow(width, height, title)
     win.run()


### PR DESCRIPTION
```
error: ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type
```
Python 3 默认用的是 unicode.
title 需要改成 bytes

ref: http://codeyarns.com/2012/04/27/pyopengl-glut-ctypes-error/

测试环境：
Windows 10 + Python 3.4 (64bit) + PyOpenGL (3.1.1a1)